### PR TITLE
Improve voice-first task entry, add Android Google TTS playback, and enlarge focus timer

### DIFF
--- a/lib/core/services/task_audio_service.dart
+++ b/lib/core/services/task_audio_service.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+final taskAudioServiceProvider = Provider<TaskAudioService>((ref) {
+  final service = TaskAudioService();
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+class TaskAudioService {
+  TaskAudioService({FlutterTts? tts}) : _tts = tts ?? FlutterTts();
+
+  final FlutterTts _tts;
+  bool _configured = false;
+
+  Future<void> speakTaskText({required String title, String? description}) async {
+    await _configure();
+    final normalizedTitle = title.trim();
+    final normalizedDescription = description?.trim() ?? '';
+    if (normalizedTitle.isEmpty && normalizedDescription.isEmpty) {
+      return;
+    }
+
+    final content = normalizedDescription.isEmpty
+        ? normalizedTitle
+        : '$normalizedTitle. $normalizedDescription';
+
+    await _tts.stop();
+    await _tts.speak(content);
+  }
+
+  Future<void> stop() async {
+    await _tts.stop();
+  }
+
+  Future<void> _configure() async {
+    if (_configured) {
+      return;
+    }
+
+    if (Platform.isAndroid) {
+      await _tts.setEngine('com.google.android.tts');
+    }
+
+    await _tts.setSpeechRate(0.45);
+    await _tts.setPitch(1.0);
+    await _tts.awaitSpeakCompletion(true);
+    _configured = true;
+  }
+
+  Future<void> dispose() async {
+    await _tts.stop();
+  }
+}

--- a/lib/features/focus/focus_run_screen.dart
+++ b/lib/features/focus/focus_run_screen.dart
@@ -218,6 +218,11 @@ class _FocusRunScreenState extends State<FocusRunScreen> {
                     ),
                   ],
                 ),
+                _FullscreenTimerOverlay(
+                  elapsedSeconds: _elapsedSeconds,
+                  timerProgress: timerProgress,
+                  running: _running,
+                ),
                 _CelebrationLayer(visible: _showCelebration),
               ],
             ),
@@ -294,6 +299,80 @@ class _FocusRunScreenState extends State<FocusRunScreen> {
       return;
     }
     Navigator.of(context).pop(result);
+  }
+}
+
+class _FullscreenTimerOverlay extends StatelessWidget {
+  const _FullscreenTimerOverlay({
+    required this.elapsedSeconds,
+    required this.timerProgress,
+    required this.running,
+  });
+
+  final int elapsedSeconds;
+  final double timerProgress;
+  final bool running;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.glitchPalette;
+    return IgnorePointer(
+      ignoring: true,
+      child: Center(
+        child: AnimatedScale(
+          duration: const Duration(milliseconds: 300),
+          scale: running ? 1 : 0.96,
+          curve: Curves.easeOutBack,
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 280),
+            opacity: running ? 0.94 : 0.72,
+            child: Container(
+              width: 250,
+              height: 250,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: palette.surface.withValues(alpha: 0.42),
+                border: Border.all(color: palette.surfaceStroke, width: 1.5),
+              ),
+              child: Stack(
+                alignment: Alignment.center,
+                children: <Widget>[
+                  SizedBox(
+                    width: 222,
+                    height: 222,
+                    child: CircularProgressIndicator(
+                      value: timerProgress,
+                      strokeWidth: 14,
+                      backgroundColor: palette.surfaceRaised,
+                    ),
+                  ),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(
+                        formatTimer(elapsedSeconds),
+                        style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        running ? 'FOCUS RUNNING' : 'PAUSED',
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          letterSpacing: 1.2,
+                          color: palette.textMuted,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/focus/widgets/focus_task_card.dart
+++ b/lib/features/focus/widgets/focus_task_card.dart
@@ -159,7 +159,7 @@ class FocusTaskCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             SizedBox(
-              height: 112,
+              height: 148,
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: palette.surfaceRaised,
@@ -174,20 +174,20 @@ class FocusTaskCard extends StatelessWidget {
                   child: Row(
                     children: <Widget>[
                       SizedBox(
-                        width: 84,
-                        height: 84,
+                        width: 126,
+                        height: 126,
                         child: Stack(
                           alignment: Alignment.center,
                           children: <Widget>[
                             CircularProgressIndicator(
                               value: timerProgress,
-                              strokeWidth: 7,
+                              strokeWidth: 11,
                               backgroundColor: palette.surface,
                             ),
                             Text(
                               formatTimer(elapsedSeconds),
-                              style: textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w700,
+                              style: textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.w800,
                               ),
                             ),
                           ],
@@ -203,8 +203,8 @@ class FocusTaskCard extends StatelessWidget {
                               running ? 'Timer running' : 'Timer paused',
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w700,
+                              style: textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.w800,
                               ),
                             ),
                             const SizedBox(height: 4),

--- a/lib/features/tasks/task_creation_sheet.dart
+++ b/lib/features/tasks/task_creation_sheet.dart
@@ -178,6 +178,7 @@ class _TaskCreationSheetState extends ConsumerState<TaskCreationSheet> {
                     .setVoiceTypingAllowNetworkFallback(value);
               },
               textInputAction: TextInputAction.next,
+              alwaysShowMicButton: true,
               onTapOutside: (_) => FocusScope.of(context).unfocus(),
               onChanged: (_) {
                 if (_titleError != null || _saving) {
@@ -190,7 +191,7 @@ class _TaskCreationSheetState extends ConsumerState<TaskCreationSheet> {
               },
               decoration: InputDecoration(
                 labelText: 'Title',
-                hintText: 'What needs focus?',
+                hintText: 'What needs focus? Tap mic to talk.',
                 errorText: _titleError,
               ),
             ),
@@ -521,12 +522,13 @@ class _TaskCreationSheetState extends ConsumerState<TaskCreationSheet> {
                     .setVoiceTypingAllowNetworkFallback(value);
               },
               minLines: 3,
+              alwaysShowMicButton: true,
               maxLines: 5,
               onTapOutside: (_) => FocusScope.of(context).unfocus(),
               scrollPadding: const EdgeInsets.only(bottom: 180),
               decoration: const InputDecoration(
                 labelText: 'Description',
-                hintText: 'Optional context',
+                hintText: 'Optional context. Tap mic to dictate.',
               ),
             ),
             const SizedBox(height: 20),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   package_info_plus: ^8.0.2
   url_launcher: ^6.3.1
   speech_to_text: ^7.3.0
+  flutter_tts: ^4.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Make the app more voice-first so users can create tasks with one tap and clearly see/toggle speech input controls for title and description. 
- Let users hear what was captured by adding local TTS playback of the task text using the device's Android Google TTS engine by default. 
- Reduce visual interference between the timer and circular progress and provide a large, centralized timer on full-screen focus to make focus state obvious.

### Description
- Added an `alwaysShowMicButton` option and tap-to-toggle (start/stop) mic behavior to `VoiceTypingTextField` so a mic button can be shown independently of keyboard focus and supports long-press streaming as before (`lib/shared/widgets/voice_typing_text_field.dart`).
- Enabled always-visible mic buttons for Title and Description fields and updated hint copy in the task creation sheet to nudge users to tap the mic to dictate (`lib/features/tasks/task_creation_sheet.dart`).
- Introduced `TaskAudioService` backed by `flutter_tts` that configures the engine to `com.google.android.tts` on Android and exposes `speakTaskText`/`stop` API via a provider (`lib/core/services/task_audio_service.dart`, `pubspec.yaml`).
- Added a play icon button to `TaskCard` that plays the source task text (title + description) using the new audio service and updated the widget to a `ConsumerStatefulWidget` (`lib/features/tasks/task_card.dart`).
- Increased the in-card timer size and stroke width to avoid overlap, and added a large animated centered full-screen timer overlay in focus run mode to make the timer much more prominent (`lib/features/focus/widgets/focus_task_card.dart`, `lib/features/focus/focus_run_screen.dart`).

### Testing
- `git diff --check` was executed as a quick automated check and passed without reported issues.
- `flutter test` was attempted to run the project's automated test suite but failed to run in this environment because the `flutter` CLI is not installed (error: `flutter: command not found`).
- An automated screenshot attempt via a Playwright script was run but could not capture a running local endpoint (`ERR_EMPTY_RESPONSE`), so UI runtime validation was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d44336690832f9aa9594f6bdf0328)